### PR TITLE
Special case handling for normalizing sharepoint uris.

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "mocha": "9.0.0",
     "mustache": "^4.0.1",
     "mustache-express": "^1.3.0",
+    "normalize-url": "^6.0.1",
     "npm-packlist": "^2.0.1",
     "postcss": "^8.0.3",
     "postcss-url": "^10.0.0",

--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -155,7 +155,7 @@ const configDefinitions = {
   },
   tagProviderUrl: {
     getValue: settings => settings.hostPageSetting('tagProviderUrl'),
-  }
+  },
 };
 
 /**

--- a/src/annotator/util/normalizers/uri.js
+++ b/src/annotator/util/normalizers/uri.js
@@ -1,0 +1,52 @@
+/**
+ * Return a normalized version of a URI.
+ *
+ * This makes it absolute and strips the fragment identifier.
+ *
+ * @param {string} uri - Relative or absolute URL
+ * @param {string} [base] - Base URL to resolve relative to. Defaults to
+ *   the document's base URL.
+ */
+export function normalizeURIWithFragment(uri, base = document.baseURI) {
+  const absUrl = new URL(uri, base).href;
+
+  // Remove the fragment identifier.
+  // This is done on the serialized URL rather than modifying `url.hash` due to
+  // a bug in Safari.
+  // See https://github.com/hypothesis/h/issues/3471#issuecomment-226713750
+  return absUrl.toString().replace(/#.*/, '');
+}
+
+/**
+ * Return a normalized version of a Sharepoint URI.
+ *
+ * There are multiple query parameters which track previous navigation and searches
+ * which make it difficult to establish a canonical URI for a document.
+ *
+ * This function will remove all query parameters from a sharepoint document link
+ * that are unnecessary for the canonical version (id and parent)
+ *
+ * @param {string} uri - Relative or absolute URL
+ * @param {string} [base] - Base URL to resolve relative to. Defaults to
+ *   the document's base URL.
+ */
+const normalizeUrl = require('normalize-url');
+
+export function normalizeSharepointURI(uri, base = document.baseURI) {
+  let absUrl = new URL(uri, base);
+
+  if (absUrl.host.includes('.sharepoint.com')) {
+    return normalizeUrl(absUrl.toString(), {
+      sortQueryParameters: true,
+      removeQueryParameters: ['e', 'p', 'q', 'originalPath', 'parentview'],
+      stripAuthentication: true,
+      stripHash: true,
+      forceHttps: true,
+      stripWWW: true,
+      removeTrailingSlash: true,
+      removeSingleSlash: true,
+    });
+  }
+
+  return absUrl.toString();
+}

--- a/src/annotator/util/test/url-test.js
+++ b/src/annotator/util/test/url-test.js
@@ -28,5 +28,28 @@ describe('annotator.util.url', () => {
         assert.equal(normalizeURI(url), url);
       });
     });
+
+    it('removes superfluous query parameters from sharepoint documents', () => {
+      const url =
+        'https://anyold.sharepoint.com/sites/foo/bar.aspx?p=true&originalPath=/foo/bar/baz&e=123456&id=%2Fsites%2Ffoo%2FBar_Baz-Biz.pdf&parent=%2Fsites%2Ffoo';
+      assert.equal(
+        normalizeURI(url),
+        'https://anyold.sharepoint.com/sites/foo/bar.aspx?id=%2Fsites%2Ffoo%2FBar_Baz-Biz.pdf&parent=%2Fsites%2Ffoo'
+      );
+    });
+
+    it('alphabetically orders canonical query parameters from sharepoint documents', () => {
+      const url =
+        'https://anyold.sharepoint.com/sites/foo/bar.aspx?parent=%2Fsites%2Ffoo&id=%2Fsites%2Ffoo%2FBar_Baz-Biz.pdf';
+      assert.equal(
+        normalizeURI(url),
+        'https://anyold.sharepoint.com/sites/foo/bar.aspx?id=%2Fsites%2Ffoo%2FBar_Baz-Biz.pdf&parent=%2Fsites%2Ffoo'
+      );
+    });
+
+    it('does not modify non-sharepoint URIs', () => {
+      const url = 'http://example.com/wibble?p=true';
+      assert.equal(normalizeURI(url), url);
+    });
   });
 });

--- a/src/annotator/util/url.js
+++ b/src/annotator/util/url.js
@@ -7,12 +7,14 @@
  * @param {string} [base] - Base URL to resolve relative to. Defaults to
  *   the document's base URL.
  */
-export function normalizeURI(uri, base = document.baseURI) {
-  const absUrl = new URL(uri, base).href;
+import {
+  normalizeSharepointURI,
+  normalizeURIWithFragment,
+} from './normalizers/uri';
 
-  // Remove the fragment identifier.
-  // This is done on the serialized URL rather than modifying `url.hash` due to
-  // a bug in Safari.
-  // See https://github.com/hypothesis/h/issues/3471#issuecomment-226713750
-  return absUrl.toString().replace(/#.*/, '');
+export function normalizeURI(uri, base = document.baseURI) {
+  const fragmentStripped = normalizeURIWithFragment(uri, base);
+  const sharepointNormalized = normalizeSharepointURI(fragmentStripped, base);
+
+  return sharepointNormalized;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5930,6 +5930,11 @@ normalize-range@^0.1.2:
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
   integrity sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=
 
+normalize-url@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-6.0.1.tgz#a4f27f58cf8c7b287b440b8a8201f42d0b00d256"
+  integrity sha512-VU4pzAuh7Kip71XEmO9aNREYAdMHFGTVj/i+CaTImS8x0i1d3jUZkXhqluy/PRgjPLMgsLQulYY3PJ/aSbSjpQ==
+
 now-and-later@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/now-and-later/-/now-and-later-2.0.1.tgz#8e579c8685764a7cc02cb680380e94f43ccb1f7c"


### PR DESCRIPTION
This change enables links to hosted sharepoint content to bypass the bouncer and land directly on sharepoint pages (with sidebar closed). 